### PR TITLE
Use market default languange when loading settings from Commerce Manager

### DIFF
--- a/src/Klarna.Checkout.CommerceManager/Apps/Order/Payments/Plugins/KlarnaCheckout/ConfigurePayment.ascx.cs
+++ b/src/Klarna.Checkout.CommerceManager/Apps/Order/Payments/Plugins/KlarnaCheckout/ConfigurePayment.ascx.cs
@@ -28,7 +28,7 @@ namespace Klarna.Checkout.CommerceManager.Apps.Order.Payments.Plugins.KlarnaChec
             if (markets == null || markets.Length == 0) return;
 
             var market = _marketService.GetMarket(markets.First().MarketId);
-            var checkoutConfiguration = GetConfiguration(markets.First().MarketId, market.DefaultLanguage.Name);
+            var checkoutConfiguration = GetConfiguration(market.MarketId, market.DefaultLanguage.Name);
             BindConfigurationData(checkoutConfiguration);
             BindMarketData(markets);
         }

--- a/src/Klarna.Checkout/DefaultCheckoutConfigurationLoader.cs
+++ b/src/Klarna.Checkout/DefaultCheckoutConfigurationLoader.cs
@@ -12,16 +12,21 @@ namespace Klarna.Checkout
     [ServiceConfiguration(typeof(ICheckoutConfigurationLoader))]
     public class DefaultCheckoutConfigurationLoader : ICheckoutConfigurationLoader
     {
-        public CheckoutConfiguration GetConfiguration(MarketId marketId)
+        public CheckoutConfiguration GetConfiguration(MarketId marketId, string languageId)
         {
             var paymentMethod = PaymentManager.GetPaymentMethodBySystemName(
-                Constants.KlarnaCheckoutSystemKeyword, ContentLanguage.PreferredCulture.Name, returnInactive: true);
+                Constants.KlarnaCheckoutSystemKeyword, languageId, returnInactive: true);
             if (paymentMethod == null)
             {
                 throw new Exception(
                     $"PaymentMethod {Constants.KlarnaCheckoutSystemKeyword} is not configured for market {marketId} and language {ContentLanguage.PreferredCulture.Name}");
             }
             return GetKlarnaCheckoutConfiguration(paymentMethod, marketId);
+        }
+
+        public CheckoutConfiguration GetConfiguration(MarketId marketId)
+        {
+            return GetConfiguration(marketId, ContentLanguage.PreferredCulture.Name);
         }
 
         private static CheckoutConfiguration GetKlarnaCheckoutConfiguration(

--- a/src/Klarna.Checkout/ICheckoutConfigurationLoader.cs
+++ b/src/Klarna.Checkout/ICheckoutConfigurationLoader.cs
@@ -5,5 +5,7 @@ namespace Klarna.Checkout
     public interface ICheckoutConfigurationLoader
     {
         CheckoutConfiguration GetConfiguration(MarketId marketId);
+
+        CheckoutConfiguration GetConfiguration(MarketId marketId, string languageId);
     }
 }


### PR DESCRIPTION
When loading settings for different countries ContentLanguage.PreferredCulture.Name was used.
If I had a payment method with language Swedish, the settings page always came back empty since no payment method was found for market SV with language English.