### PR TITLE
Fix for shipment amount validation issue when updating shipping option

### DIFF
--- a/src/Klarna.Checkout/CartExtensions.cs
+++ b/src/Klarna.Checkout/CartExtensions.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using EPiServer.Commerce.Order;
+
+namespace Klarna.Checkout
+{
+    public static class CartExtensions
+    {
+        public static void AddValidationIssues(
+            this Dictionary<ILineItem, List<ValidationIssue>> issues,
+            ILineItem lineItem,
+            ValidationIssue issue)
+        {
+            if (!issues.ContainsKey(lineItem))
+            {
+                issues.Add(lineItem, new List<ValidationIssue>());
+            }
+
+            if (!issues[lineItem].Contains(issue))
+            {
+                issues[lineItem].Add(issue);
+            }
+        }
+    }
+}

--- a/src/Klarna.Checkout/DefaultKlarnaCartValidator.cs
+++ b/src/Klarna.Checkout/DefaultKlarnaCartValidator.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using EPiServer.Commerce.Marketing;
+using EPiServer.Commerce.Order;
+using EPiServer.ServiceLocation;
+using Mediachase.Commerce.Customers;
+
+namespace Klarna.Checkout
+{
+    [ServiceConfiguration(typeof(IKlarnaCartValidator))]
+    public class DefaultKlarnaCartValidator : IKlarnaCartValidator
+    {
+        private readonly ILineItemValidator _lineItemValidator;
+        private readonly IPlacedPriceProcessor _placedPriceProcessor;
+        private readonly IInventoryProcessor _inventoryProcessor;
+        private readonly CustomerContext _customerContext;
+        private readonly IPromotionEngine _promotionEngine;
+
+        public DefaultKlarnaCartValidator(
+            ILineItemValidator lineItemValidator,
+            IPlacedPriceProcessor placedPriceProcessor,
+            IInventoryProcessor inventoryProcessor,
+            CustomerContext customerContext,
+            IPromotionEngine promotionEngine)
+        {
+            _lineItemValidator = lineItemValidator;
+            _placedPriceProcessor = placedPriceProcessor;
+            _inventoryProcessor = inventoryProcessor;
+            _customerContext = customerContext;
+            _promotionEngine = promotionEngine;
+        }
+        
+        public virtual Dictionary<ILineItem, List<ValidationIssue>> ValidateCart(ICart cart)
+        {
+            var validationIssues = new Dictionary<ILineItem, List<ValidationIssue>>();
+            cart.ValidateOrRemoveLineItems((item, issue) => validationIssues.AddValidationIssues(item, issue), _lineItemValidator);
+            cart.UpdatePlacedPriceOrRemoveLineItems(_customerContext.GetContactById(cart.CustomerId), (item, issue) => validationIssues.AddValidationIssues(item, issue), _placedPriceProcessor);
+            cart.UpdateInventoryOrRemoveLineItems((item, issue) => validationIssues.AddValidationIssues(item, issue), _inventoryProcessor);
+
+            return validationIssues;
+        }
+        
+        public virtual IEnumerable<RewardDescription> ApplyDiscounts(ICart cart, RequestFulfillmentStatus requestedStatuses = RequestFulfillmentStatus.Fulfilled)
+        {
+            return cart.ApplyDiscounts(_promotionEngine, new PromotionEngineSettings
+            {
+                RequestedStatuses = requestedStatuses,
+                ExclusionLevel = ExclusionLevel.Unit
+            });
+        }
+    }
+}

--- a/src/Klarna.Checkout/IKlarnaCartValidator.cs
+++ b/src/Klarna.Checkout/IKlarnaCartValidator.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using EPiServer.Commerce.Marketing;
+using EPiServer.Commerce.Order;
+
+namespace Klarna.Checkout
+{
+    public interface IKlarnaCartValidator
+    {
+        Dictionary<ILineItem, List<ValidationIssue>> ValidateCart(ICart cart);
+        IEnumerable<RewardDescription> ApplyDiscounts(ICart cart, RequestFulfillmentStatus requestedStatuses = RequestFulfillmentStatus.Fulfilled);
+    }
+}

--- a/src/Klarna.Checkout/Klarna.Checkout.v3.csproj
+++ b/src/Klarna.Checkout/Klarna.Checkout.v3.csproj
@@ -218,12 +218,15 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CartExtensions.cs" />
     <Compile Include="CheckoutConfiguration.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="DefaultCheckoutConfigurationLoader.cs" />
     <Compile Include="DefaultCheckoutLanguageIdConverter.cs" />
+    <Compile Include="DefaultKlarnaCartValidator.cs" />
     <Compile Include="ICheckoutConfigurationLoader.cs" />
     <Compile Include="ICheckoutLanguageIdConverter.cs" />
+    <Compile Include="IKlarnaCartValidator.cs" />
     <Compile Include="IKlarnaCheckoutService.cs" />
     <Compile Include="IKlarnaOrderValidator.cs" />
     <Compile Include="ICheckoutOrderDataBuilder.cs" />

--- a/src/Klarna.Checkout/KlarnaCheckoutService.cs
+++ b/src/Klarna.Checkout/KlarnaCheckoutService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net;
+using EPiServer.Commerce.Marketing;
 using EPiServer.Commerce.Order;
 using EPiServer.Globalization;
 using EPiServer.ServiceLocation;
@@ -38,6 +39,7 @@ namespace Klarna.Checkout
         private readonly KlarnaOrderServiceFactory _klarnaOrderServiceFactory;
         private readonly IOrderRepository _orderRepository;
         private readonly ICheckoutLanguageIdConverter _checkoutLanguageIdConverter;
+        private readonly IKlarnaCartValidator _klarnaCartValidator;
 
         private Client _client;
         private PaymentMethodDto _paymentMethodDto;
@@ -51,7 +53,8 @@ namespace Klarna.Checkout
             IMarketService marketService,
             ICheckoutConfigurationLoader checkoutConfigurationLoader,
             KlarnaOrderServiceFactory klarnaOrderServiceFactory,
-            ICheckoutLanguageIdConverter checkoutLanguageIdConverter)
+            ICheckoutLanguageIdConverter checkoutLanguageIdConverter,
+            IKlarnaCartValidator klarnaCartValidator)
             : base(orderRepository, paymentProcessor, orderGroupCalculator, marketService)
         {
             _orderGroupCalculator = orderGroupCalculator;
@@ -61,6 +64,7 @@ namespace Klarna.Checkout
             _checkoutConfigurationLoader = checkoutConfigurationLoader;
             _klarnaOrderServiceFactory = klarnaOrderServiceFactory;
             _checkoutLanguageIdConverter = checkoutLanguageIdConverter;
+            _klarnaCartValidator = klarnaCartValidator;
         }
 
         public virtual PaymentMethodDto PaymentMethodDto =>
@@ -324,10 +328,15 @@ namespace Klarna.Checkout
         {
             var configuration = GetConfiguration(cart.MarketId);
             var shipment = cart.GetFirstShipment();
+            Dictionary<ILineItem, List<ValidationIssue>> validationIssues = null;
+            IEnumerable<RewardDescription> rewardDescriptions = null;
+            
             if (shipment != null && Guid.TryParse(shippingOptionUpdateRequest.SelectedShippingOption.Id, out Guid guid))
             {
-                shipment.ShippingMethodId = guid;
                 shipment.ShippingAddress = shippingOptionUpdateRequest.ShippingAddress.ToOrderAddress(cart);
+                shipment.ShippingMethodId = guid;
+                validationIssues = _klarnaCartValidator.ValidateCart(cart);
+                rewardDescriptions = _klarnaCartValidator.ApplyDiscounts(cart);
                 _orderRepository.Save(cart);
             }
 
@@ -337,13 +346,17 @@ namespace Klarna.Checkout
                 OrderAmount = AmountHelper.GetAmount(totals.Total),
                 OrderTaxAmount = AmountHelper.GetAmount(totals.TaxTotal),
                 OrderLines = GetOrderLines(cart, totals, configuration.SendProductAndImageUrl),
-                PurchaseCurrency = cart.Currency.CurrencyCode
+                PurchaseCurrency = cart.Currency.CurrencyCode,
+                ShippingOptions = configuration.ShippingOptionsInIFrame ? GetShippingOptions(cart, cart.Currency, ContentLanguage.PreferredCulture) : Enumerable.Empty<ShippingOption>(),
+                ValidationIssues = validationIssues,
+                RewardDescriptions = rewardDescriptions
             };
 
             if (ServiceLocator.Current.TryGetExistingInstance(out ICheckoutOrderDataBuilder checkoutOrderDataBuilder))
             {
                 checkoutOrderDataBuilder.Build(result, cart, configuration);
             }
+            
             return result;
         }
 
@@ -351,9 +364,14 @@ namespace Klarna.Checkout
         {
             var configuration = GetConfiguration(cart.MarketId);
             var shipment = cart.GetFirstShipment();
+            Dictionary<ILineItem, List<ValidationIssue>> validationIssues = null;
+            IEnumerable<RewardDescription> rewardDescriptions = null;
+            
             if (shipment != null)
             {
                 shipment.ShippingAddress = addressUpdateRequest.ShippingAddress.ToOrderAddress(cart);
+                validationIssues = _klarnaCartValidator.ValidateCart(cart);
+                rewardDescriptions = _klarnaCartValidator.ApplyDiscounts(cart);
                 _orderRepository.Save(cart);
             }
 
@@ -364,13 +382,16 @@ namespace Klarna.Checkout
                 OrderTaxAmount = AmountHelper.GetAmount(totals.TaxTotal),
                 OrderLines = GetOrderLines(cart, totals, configuration.SendProductAndImageUrl),
                 PurchaseCurrency = cart.Currency.CurrencyCode,
-                ShippingOptions = configuration.ShippingOptionsInIFrame ? GetShippingOptions(cart, cart.Currency, ContentLanguage.PreferredCulture) : Enumerable.Empty<ShippingOption>()
+                ShippingOptions = configuration.ShippingOptionsInIFrame ? GetShippingOptions(cart, cart.Currency, ContentLanguage.PreferredCulture) : Enumerable.Empty<ShippingOption>(),
+                ValidationIssues = validationIssues,
+                RewardDescriptions = rewardDescriptions
             };
 
             if (ServiceLocator.Current.TryGetExistingInstance(out ICheckoutOrderDataBuilder checkoutOrderDataBuilder))
             {
                 checkoutOrderDataBuilder.Build(result, cart, configuration);
             }
+            
             return result;
         }
 
@@ -380,6 +401,7 @@ namespace Klarna.Checkout
             var market = _marketService.GetMarket(cart.MarketId);
             var localCheckoutOrderData = (PatchedCheckoutOrderData)GetCheckoutOrderData(cart, market, PaymentMethodDto);
             localCheckoutOrderData.ShippingAddress = cart.GetFirstShipment().ShippingAddress.ToAddress();
+            
             if (!_klarnaOrderValidator.Compare(checkoutData, localCheckoutOrderData))
             {
                 return false;
@@ -481,6 +503,7 @@ namespace Klarna.Checkout
                 shippingOptions.FirstOrDefault(x => x.Id.Equals(shipment.ShippingMethodId.ToString()));
             if (selectedShipment != null)
             {
+                shippingOptions.ForEach(option => option.PreSelected = false);
                 selectedShipment.PreSelected = true;
             }
             return shippingOptions;

--- a/src/Klarna.Checkout/KlarnaCheckoutService.cs
+++ b/src/Klarna.Checkout/KlarnaCheckoutService.cs
@@ -328,8 +328,8 @@ namespace Klarna.Checkout
         {
             var configuration = GetConfiguration(cart.MarketId);
             var shipment = cart.GetFirstShipment();
-            Dictionary<ILineItem, List<ValidationIssue>> validationIssues = null;
-            IEnumerable<RewardDescription> rewardDescriptions = null;
+            var validationIssues = new Dictionary<ILineItem, List<ValidationIssue>>();
+            var rewardDescriptions = Enumerable.Empty<RewardDescription>();
             
             if (shipment != null && Guid.TryParse(shippingOptionUpdateRequest.SelectedShippingOption.Id, out Guid guid))
             {
@@ -347,7 +347,9 @@ namespace Klarna.Checkout
                 OrderTaxAmount = AmountHelper.GetAmount(totals.TaxTotal),
                 OrderLines = GetOrderLines(cart, totals, configuration.SendProductAndImageUrl),
                 PurchaseCurrency = cart.Currency.CurrencyCode,
-                ShippingOptions = configuration.ShippingOptionsInIFrame ? GetShippingOptions(cart, cart.Currency, ContentLanguage.PreferredCulture) : Enumerable.Empty<ShippingOption>(),
+                ShippingOptions = configuration.ShippingOptionsInIFrame 
+                    ? GetShippingOptions(cart, cart.Currency, ContentLanguage.PreferredCulture)
+                    : Enumerable.Empty<ShippingOption>(),
                 ValidationIssues = validationIssues,
                 RewardDescriptions = rewardDescriptions
             };
@@ -364,8 +366,8 @@ namespace Klarna.Checkout
         {
             var configuration = GetConfiguration(cart.MarketId);
             var shipment = cart.GetFirstShipment();
-            Dictionary<ILineItem, List<ValidationIssue>> validationIssues = null;
-            IEnumerable<RewardDescription> rewardDescriptions = null;
+            var validationIssues = new Dictionary<ILineItem, List<ValidationIssue>>();
+            var rewardDescriptions = Enumerable.Empty<RewardDescription>();
             
             if (shipment != null)
             {
@@ -382,7 +384,9 @@ namespace Klarna.Checkout
                 OrderTaxAmount = AmountHelper.GetAmount(totals.TaxTotal),
                 OrderLines = GetOrderLines(cart, totals, configuration.SendProductAndImageUrl),
                 PurchaseCurrency = cart.Currency.CurrencyCode,
-                ShippingOptions = configuration.ShippingOptionsInIFrame ? GetShippingOptions(cart, cart.Currency, ContentLanguage.PreferredCulture) : Enumerable.Empty<ShippingOption>(),
+                ShippingOptions = configuration.ShippingOptionsInIFrame
+                    ? GetShippingOptions(cart, cart.Currency, ContentLanguage.PreferredCulture)
+                    : Enumerable.Empty<ShippingOption>(),
                 ValidationIssues = validationIssues,
                 RewardDescriptions = rewardDescriptions
             };

--- a/src/Klarna.Checkout/Models/AddressUpdateResponse.cs
+++ b/src/Klarna.Checkout/Models/AddressUpdateResponse.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using EPiServer.Commerce.Marketing;
+using EPiServer.Commerce.Order;
 using Klarna.Rest.Models;
 using Newtonsoft.Json;
 
@@ -29,5 +31,12 @@ namespace Klarna.Checkout.Models
 
         [JsonProperty("locale")]
         public string Locale { get; set; }
+
+        [JsonIgnore]
+        public Dictionary<ILineItem, List<ValidationIssue>> ValidationIssues { get; set; }
+        
+        [JsonIgnore]
+        public IEnumerable<RewardDescription> RewardDescriptions { get; set; }
+
     }
 }


### PR DESCRIPTION
If shipping promotion exists, amount validation threw an exception because ApplyDiscount was not called on cart when updating shipping option. Also added proper cart validation on address/shipping update since that might raise new validation issues. This commit also fixes issue #62: Empty shipping options.