### PR TITLE
Episerver Commerce 13 upgrade fixes

### DIFF
--- a/demo/Sources/EPiServer.Reference.Commerce.Site/Features/Checkout/Services/ConfirmationService.cs
+++ b/demo/Sources/EPiServer.Reference.Commerce.Site/Features/Checkout/Services/ConfirmationService.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using EPiServer.Commerce.Order;
 using EPiServer.Commerce.Order.Internal;
 using Mediachase.Commerce;
+using Mediachase.Commerce.Orders;
+using Mediachase.Commerce.Orders.Search;
 
 namespace EPiServer.Reference.Commerce.Site.Features.Checkout.Services
 {
@@ -51,6 +53,27 @@ namespace EPiServer.Reference.Commerce.Site.Features.Checkout.Services
             purchaseOrder.Forms.Add(form);
 
             return purchaseOrder;
+        }
+
+        public IPurchaseOrder GetByTrackingNumber(string trackingNumber)
+        {
+            OrderSearchOptions searchOptions = new OrderSearchOptions();
+            searchOptions.CacheResults = false;
+            searchOptions.StartingRecord = 0;
+            searchOptions.RecordsToRetrieve = 1;
+            searchOptions.Classes = new System.Collections.Specialized.StringCollection { "PurchaseOrder" };
+            searchOptions.Namespace = "Mediachase.Commerce.Orders";
+
+            var parameters = new OrderSearchParameters();
+            parameters.SqlMetaWhereClause = $"META.TrackingNumber = '{trackingNumber}'";
+
+            var purchaseOrder = OrderContext.Current.FindPurchaseOrders(parameters, searchOptions)?.FirstOrDefault();
+
+            if (purchaseOrder != null)
+            {
+                return _orderRepository.Load<IPurchaseOrder>(purchaseOrder.OrderGroupId);
+            }
+            return null;
         }
     }
 }

--- a/demo/Sources/EPiServer.Reference.Commerce.Site/Views/Checkout/SingleShipmentCheckout.cshtml
+++ b/demo/Sources/EPiServer.Reference.Commerce.Site/Views/Checkout/SingleShipmentCheckout.cshtml
@@ -136,4 +136,5 @@
             </div>
         }
     </form>
+    <div id="loading-overlay" class="loading" style="display: none">Loading&#8230;</div>
 </div>

--- a/demo/Sources/EPiServer.Reference.Commerce.Site/Views/Payment/_PaymentMethodSelection.cshtml
+++ b/demo/Sources/EPiServer.Reference.Commerce.Site/Views/Payment/_PaymentMethodSelection.cshtml
@@ -1,9 +1,12 @@
 ﻿@model EPiServer.Reference.Commerce.Site.Features.Payment.ViewModels.PaymentMethodSelectionViewModel
 @{
     Layout = null;
+
+    var isSingleMethod = Model.PaymentMethods.Count() == 1;
+    var inlineStyle = isSingleMethod ? "style=\"display: none;\"" : string.Empty;
 }
 
-<div class="payment-methods">
+<div class="payment-methods" @Html.Raw(inlineStyle) >
     <div class="row">
         <div class="col-xs-12">
             <h3>@Html.Translate("/Checkout/Payment/Labels/ChoosePayment")</h3>


### PR DESCRIPTION
- Fixed order confirmation page not working for Klarna Payments,
- Fixed "loading" not working on the checkout page.
- Fixed visible payment selection when only one item (now selection is hidden).
- Fixed error when Klarna Checkout fails to initialize when it is not enabled.