### PR TITLE
Added Episerver Commerce version to request headers instead of Cms

### DIFF
--- a/src/Klarna.Checkout/KlarnaCheckoutService.cs
+++ b/src/Klarna.Checkout/KlarnaCheckoutService.cs
@@ -84,8 +84,8 @@ namespace Klarna.Checkout
             {
                 var connectionConfiguration = GetCheckoutConfiguration(market);
                 var connector = ConnectorFactory.Create(connectionConfiguration.Username, connectionConfiguration.Password, new Uri(connectionConfiguration.ApiUrl));
-                connector.UserAgent.AddField("Platform", "EPiServer", typeof(EPiServer.Core.IContent).Assembly.GetName().Version.ToString(), new string[0]);
-                connector.UserAgent.AddField("Module", "Klarna.Checkout", typeof(KlarnaCheckoutService).Assembly.GetName().Version.ToString(), new string[0]);
+                connector.UserAgent.AddField("Platform", "Episerver.Commerce_", typeof(EPiServer.Commerce.ApplicationContext).Assembly.GetName().Version.ToString(), new string[0]);
+                connector.UserAgent.AddField("Module", "Klarna.Checkout_", typeof(KlarnaCheckoutService).Assembly.GetName().Version.ToString(), new string[0]);
 
                 _client = new Client(connector);
             }

--- a/src/Klarna.OrderManagement/KlarnaOrderServiceFactory.cs
+++ b/src/Klarna.OrderManagement/KlarnaOrderServiceFactory.cs
@@ -41,8 +41,8 @@ namespace Klarna.OrderManagement
             };
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", Convert.ToBase64String(byteArray));
 
-            httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Platform", $"EPiServer_{typeof(EPiServer.Core.IContent).Assembly.GetName().Version.ToString()}"));
-            httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Module", $"Klarna.OrderManagement_{typeof(Klarna.OrderManagement.KlarnaOrderService).Assembly.GetName().Version.ToString()}"));
+            httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Platform", $"Episerver.Commerce_{typeof(EPiServer.Commerce.ApplicationContext).Assembly.GetName().Version}"));
+            httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Module", $"Klarna.OrderManagement_{typeof(KlarnaOrderService).Assembly.GetName().Version}"));
 
             return new KlarnaOrderService(client, RestService.For<IKlarnaOrderServiceApi>(httpClient));
         }

--- a/src/Klarna.Payments/KlarnaServiceApiFactory.cs
+++ b/src/Klarna.Payments/KlarnaServiceApiFactory.cs
@@ -37,8 +37,8 @@ namespace Klarna.Payments
             };
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", Convert.ToBase64String(byteArray));
             
-            httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Platform", $"EPiServer_{typeof(EPiServer.Core.IContent).Assembly.GetName().Version.ToString()}"));
-            httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Module", $"Klarna.Payments_{typeof(Klarna.Payments.KlarnaPaymentsService).Assembly.GetName().Version.ToString()}"));
+            httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Platform", $"Episerver.Commerce_{typeof(EPiServer.Commerce.ApplicationContext).Assembly.GetName().Version}"));
+            httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Module", $"Klarna.Payments_{typeof(KlarnaPaymentsService).Assembly.GetName().Version}"));
 
             return RestService.For<IKlarnaServiceApi>(httpClient);
         }


### PR DESCRIPTION
Fixes #74 - this will provide better logging for which Episerver Commerce versions merchants are running