### PR TITLE
Fix incorrect language comparison

### DIFF
--- a/src/Klarna.Common/DefaultLanguageService.cs
+++ b/src/Klarna.Common/DefaultLanguageService.cs
@@ -23,11 +23,11 @@ namespace Klarna.Common
             var languages = _languageBranchRepository.ListEnabled();
             var currentLanguage = ContentLanguage.PreferredCulture;
 
-            if (languages.Any(x => x.Name == Thread.CurrentThread.CurrentCulture.Name))
+            if (languages.Any(x => x.Culture.Name == Thread.CurrentThread.CurrentCulture.Name))
             {
                 currentLanguage = Thread.CurrentThread.CurrentCulture;
             }
-            else if (languages.Any(x => x.Name == Thread.CurrentThread.CurrentCulture.Parent.Name))
+            else if (languages.Any(x => x.Culture.Name == Thread.CurrentThread.CurrentCulture.Parent.Name))
             {
                 currentLanguage = Thread.CurrentThread.CurrentCulture.Parent;
             }


### PR DESCRIPTION
The **name** property from LanguageBranch is different to CultureInfo **name** property (see attached screenshot), the comparison never gets executed.

![image](https://user-images.githubusercontent.com/332991/109789971-fbeb2e80-7c64-11eb-8403-4fd908d48c76.png)
