### PR TITLE
Fix issue with string.empty

### DIFF
--- a/src/Klarna.Common/Extensions/SiteUrlExtensions.cs
+++ b/src/Klarna.Common/Extensions/SiteUrlExtensions.cs
@@ -8,7 +8,7 @@ namespace Klarna.Common.Extensions
         public static string ToAbsoluteUrl(this string url)
         {
             var siteUri = SiteUrlHelper.GetCurrentSiteUrl();
-            if (siteUri == null || url == null) return string.Empty;
+            if (siteUri == null || url == null) return null;
             return new Uri(siteUri, url).ToString();
         }
     }


### PR DESCRIPTION
Klarna api returns BadRequest when we send in empty string on Url and ImageUrl on line item.

Checkout fails to load when variationContent has no image.