### PR TITLE
Update OrderManagementInitialPaymentMethodType with missing payment methods

### DIFF
--- a/src/Klarna.Common/Models/OrderManagementInitialPaymentMethodType.cs
+++ b/src/Klarna.Common/Models/OrderManagementInitialPaymentMethodType.cs
@@ -1,5 +1,7 @@
-﻿namespace Klarna.Common.Models
+namespace Klarna.Common.Models
 {
+    // IMPORTANT: This list needs to be kept up to date with
+    // https://docs.kustom.co/contents/api/order-management/orders/getorder#orders/getorder/t=response&c=200&path=initial_payment_method/type
     public enum OrderManagementInitialPaymentMethodType
     {
         INVOICE,
@@ -18,6 +20,13 @@
         PAY_LATER_BY_CARD,
         MOBILEPAY,
         OTHER,
-        SWISH
+        SWISH,
+        // Methods introduced more recently than 2023 (added to the end, to avoid number mismatches in the backing type)
+        APPLE_PAY_CARD,
+        GOOGLE_PAY_CARD,
+        CARTES_BANCAIRES,
+        BLIK,
+        TWINT,
+        BANCONTACT
     }
 }


### PR DESCRIPTION
Payments with Apple Pay and Google Pay give JSON deserialization exceptions. A look at the documentation at https://docs.kustom.co/contents/api/order-management/orders/getorder#orders/getorder/t=response&c=200&path=initial_payment_method/type shows that several new payment methods have been added. This edit fixes the problem.