### PR TITLE
Klarna.OrderManagement.Steps.PaymentStep.GetExceptionMessage no longe…

### DIFF
--- a/src/Klarna.Checkout/KlarnaCheckoutService.cs
+++ b/src/Klarna.Checkout/KlarnaCheckoutService.cs
@@ -133,7 +133,7 @@ namespace Klarna.Checkout
             }
             catch (ApiException ex)
             {
-                _logger.Error($"{ex.ErrorMessage.CorrelationId} {ex.ErrorMessage.ErrorCode} {string.Join(", ", ex.ErrorMessage.ErrorMessages)}", ex);
+                _logger.Error(FormatApiException(ex), ex);
                 throw;
             }
             catch (WebException ex)
@@ -177,7 +177,7 @@ namespace Klarna.Checkout
                     return await CreateOrder(cart).ConfigureAwait(false);
                 }
 
-                _logger.Error($"{ex.ErrorMessage.CorrelationId} {ex.ErrorMessage.ErrorCode} {string.Join(", ", ex.ErrorMessage.ErrorMessages)}", ex);
+                _logger.Error(FormatApiException(ex), ex);
 
                 throw;
             }
@@ -570,6 +570,26 @@ namespace Klarna.Checkout
         {
             var client = GetClient(market);
             return new LoggingCheckoutOrder(client);
+        }
+
+        private static string FormatApiException(ApiException ex)
+        {
+            try
+            {
+                var errorMessage = ex?.ErrorMessage;
+                if (errorMessage == null)
+                {
+                    return ex?.Message ?? string.Empty;
+                }
+                var messages = errorMessage.ErrorMessages != null
+                    ? string.Join(", ", errorMessage.ErrorMessages)
+                    : string.Empty;
+                return $"{errorMessage.CorrelationId} {errorMessage.ErrorCode} {messages}";
+            }
+            catch
+            {
+                return ex?.ToString() ?? string.Empty;
+            }
         }
     }
 }

--- a/src/Klarna.Checkout/KlarnaCheckoutService.cs
+++ b/src/Klarna.Checkout/KlarnaCheckoutService.cs
@@ -133,7 +133,7 @@ namespace Klarna.Checkout
             }
             catch (ApiException ex)
             {
-                _logger.Error(FormatApiException(ex), ex);
+                _logger.Error(ex.GetFormattedErrorMessage(), ex);
                 throw;
             }
             catch (WebException ex)
@@ -177,7 +177,7 @@ namespace Klarna.Checkout
                     return await CreateOrder(cart).ConfigureAwait(false);
                 }
 
-                _logger.Error(FormatApiException(ex), ex);
+                _logger.Error(ex.GetFormattedErrorMessage(), ex);
 
                 throw;
             }
@@ -570,26 +570,6 @@ namespace Klarna.Checkout
         {
             var client = GetClient(market);
             return new LoggingCheckoutOrder(client);
-        }
-
-        private static string FormatApiException(ApiException ex)
-        {
-            try
-            {
-                var errorMessage = ex?.ErrorMessage;
-                if (errorMessage == null)
-                {
-                    return ex?.Message ?? string.Empty;
-                }
-                var messages = errorMessage.ErrorMessages != null
-                    ? string.Join(", ", errorMessage.ErrorMessages)
-                    : string.Empty;
-                return $"{errorMessage.CorrelationId} {errorMessage.ErrorCode} {messages}";
-            }
-            catch
-            {
-                return ex?.ToString() ?? string.Empty;
-            }
         }
     }
 }

--- a/src/Klarna.Checkout/LoggingCheckoutOrder.cs
+++ b/src/Klarna.Checkout/LoggingCheckoutOrder.cs
@@ -64,10 +64,25 @@ namespace Klarna.Checkout
 
         private static void Log(ApiException e)
         {
-            var messages = string.Join(" ", e.ErrorMessage.ErrorMessages);
-            Logger.Error(
-                $"Error Code: '{e.ErrorMessage.ErrorCode}'; CorrelationId: '{e.ErrorMessage.CorrelationId}'; Messages: '{messages}'",
-                e);
+            try
+            {
+                var errorMessage = e?.ErrorMessage;
+                if (errorMessage == null)
+                {
+                    Logger.Error(e?.Message, e);
+                    return;
+                }
+                var messages = errorMessage.ErrorMessages != null
+                    ? string.Join(" ", errorMessage.ErrorMessages)
+                    : string.Empty;
+                Logger.Error(
+                    $"Error Code: '{errorMessage.ErrorCode}'; CorrelationId: '{errorMessage.CorrelationId}'; Messages: '{messages}'",
+                    e);
+            }
+            catch
+            {
+                Logger.Error(e?.ToString(), e);
+            }
         }
     }
 }

--- a/src/Klarna.Checkout/LoggingCheckoutOrder.cs
+++ b/src/Klarna.Checkout/LoggingCheckoutOrder.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using EPiServer.Logging;
 using Klarna.Checkout.Models;
+using Klarna.Common.Extensions;
 using Klarna.Common.Models;
 
 namespace Klarna.Checkout
@@ -64,25 +65,7 @@ namespace Klarna.Checkout
 
         private static void Log(ApiException e)
         {
-            try
-            {
-                var errorMessage = e?.ErrorMessage;
-                if (errorMessage == null)
-                {
-                    Logger.Error(e?.Message, e);
-                    return;
-                }
-                var messages = errorMessage.ErrorMessages != null
-                    ? string.Join(" ", errorMessage.ErrorMessages)
-                    : string.Empty;
-                Logger.Error(
-                    $"Error Code: '{errorMessage.ErrorCode}'; CorrelationId: '{errorMessage.CorrelationId}'; Messages: '{messages}'",
-                    e);
-            }
-            catch
-            {
-                Logger.Error(e?.ToString(), e);
-            }
+            Logger.Error(e.GetVerboseLogMessage(), e);
         }
     }
 }

--- a/src/Klarna.Common/Extensions/ApiExceptionExtensions.cs
+++ b/src/Klarna.Common/Extensions/ApiExceptionExtensions.cs
@@ -1,0 +1,67 @@
+using Klarna.Common.Models;
+
+namespace Klarna.Common.Extensions
+{
+    public static class ApiExceptionExtensions
+    {
+        /// <summary>
+        /// Returns a compact "{CorrelationId} {ErrorCode} {messages joined by ", "}" representation of the
+        /// Klarna error, falling back to the underlying exception message when no Klarna error model is attached.
+        /// Never throws — formatting failures are swallowed in favour of returning the exception's full string
+        /// representation, so the original exception is never masked by a formatting bug.
+        /// </summary>
+        public static string GetFormattedErrorMessage(this ApiException apiException)
+        {
+            try
+            {
+                if (apiException == null)
+                {
+                    return string.Empty;
+                }
+                var errorMessage = apiException.ErrorMessage;
+                if (errorMessage == null)
+                {
+                    return apiException.Message ?? string.Empty;
+                }
+                var messages = JoinMessages(errorMessage.ErrorMessages, ", ");
+                return $"{errorMessage.CorrelationId} {errorMessage.ErrorCode} {messages}";
+            }
+            catch
+            {
+                return apiException?.ToString() ?? string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Returns a labeled log-line "Error Code: '...'; CorrelationId: '...'; Messages: '...'" used by
+        /// checkout-order logging, falling back to the underlying exception message when no Klarna error model
+        /// is attached. Never throws — see <see cref="GetFormattedErrorMessage"/>.
+        /// </summary>
+        public static string GetVerboseLogMessage(this ApiException apiException)
+        {
+            try
+            {
+                if (apiException == null)
+                {
+                    return string.Empty;
+                }
+                var errorMessage = apiException.ErrorMessage;
+                if (errorMessage == null)
+                {
+                    return apiException.Message ?? string.Empty;
+                }
+                var messages = JoinMessages(errorMessage.ErrorMessages, " ");
+                return $"Error Code: '{errorMessage.ErrorCode}'; CorrelationId: '{errorMessage.CorrelationId}'; Messages: '{messages}'";
+            }
+            catch
+            {
+                return apiException?.ToString() ?? string.Empty;
+            }
+        }
+
+        private static string JoinMessages(string[] messages, string separator)
+        {
+            return messages != null ? string.Join(separator, messages) : string.Empty;
+        }
+    }
+}

--- a/src/Klarna.Common/Klarna.Common.v3.csproj
+++ b/src/Klarna.Common/Klarna.Common.v3.csproj
@@ -226,6 +226,7 @@
     <Compile Include="BaseRestClient.cs" />
     <Compile Include="BaseStore.cs" />
     <Compile Include="ConnectionConfiguration.cs" />
+    <Compile Include="Extensions\ApiExceptionExtensions.cs" />
     <Compile Include="Extensions\ILineItemTaxCalculator.cs" />
     <Compile Include="Extensions\LineItemExtensions.cs" />
     <Compile Include="Extensions\LineItemTaxCalculator.cs" />

--- a/src/Klarna.OrderManagement/Steps/PaymentStep.cs
+++ b/src/Klarna.OrderManagement/Steps/PaymentStep.cs
@@ -47,32 +47,17 @@ namespace Klarna.OrderManagement.Steps
 
         protected string GetExceptionMessage(Exception ex)
         {
-            try
+            switch (ex)
             {
-                switch (ex)
-                {
-                    case AggregateException aggregateException:
-                        return string.Join("; ",
-                            aggregateException.InnerExceptions.Select(GetExceptionMessage));
-                    case ApiException apiException:
-                        var errorMessage = apiException.ErrorMessage;
-                        if (errorMessage == null)
-                        {
-                            return apiException.Message ?? string.Empty;
-                        }
-                        var messages = errorMessage.ErrorMessages != null
-                            ? string.Join(", ", errorMessage.ErrorMessages)
-                            : string.Empty;
-                        return $"{errorMessage.CorrelationId} {errorMessage.ErrorCode} {messages}";
-                    case WebException webException:
-                        return webException.Message;
-                }
-                return string.Empty;
+                case AggregateException aggregateException:
+                    return string.Join("; ",
+                        aggregateException.InnerExceptions.Select(GetExceptionMessage));
+                case ApiException apiException:
+                    return apiException.GetFormattedErrorMessage();
+                case WebException webException:
+                    return webException.Message;
             }
-            catch
-            {
-                return ex?.ToString() ?? string.Empty;
-            }
+            return string.Empty;
         }
     }
 }

--- a/src/Klarna.OrderManagement/Steps/PaymentStep.cs
+++ b/src/Klarna.OrderManagement/Steps/PaymentStep.cs
@@ -47,25 +47,32 @@ namespace Klarna.OrderManagement.Steps
 
         protected string GetExceptionMessage(Exception ex)
         {
-            var exceptionMessage = string.Empty;
-            switch (ex)
+            try
             {
-                case AggregateException aggregateException:
-                    var innerMessages =
-                        string.Join("; ", aggregateException.InnerExceptions.Select(GetExceptionMessage));
-                    exceptionMessage = $"{innerMessages}";
-                    break;
-                case ApiException apiException:
-                    exceptionMessage =
-                        $"{apiException.ErrorMessage.CorrelationId} " +
-                        $"{apiException.ErrorMessage.ErrorCode} " +
-                        $"{string.Join(", ", apiException.ErrorMessage.ErrorMessages)}";
-                    break;
-                case WebException webException:
-                    exceptionMessage = webException.Message;
-                    break;
+                switch (ex)
+                {
+                    case AggregateException aggregateException:
+                        return string.Join("; ",
+                            aggregateException.InnerExceptions.Select(GetExceptionMessage));
+                    case ApiException apiException:
+                        var errorMessage = apiException.ErrorMessage;
+                        if (errorMessage == null)
+                        {
+                            return apiException.Message ?? string.Empty;
+                        }
+                        var messages = errorMessage.ErrorMessages != null
+                            ? string.Join(", ", errorMessage.ErrorMessages)
+                            : string.Empty;
+                        return $"{errorMessage.CorrelationId} {errorMessage.ErrorCode} {messages}";
+                    case WebException webException:
+                        return webException.Message;
+                }
+                return string.Empty;
             }
-            return exceptionMessage;
+            catch
+            {
+                return ex?.ToString() ?? string.Empty;
+            }
         }
     }
 }


### PR DESCRIPTION
…r crashes on string.Join(sep, null) when Klarna returns an error response whose error_messages array (or whole ErrorMessage) is null.

The original ApiException is preserved through the catch handler instead of being replaced by ArgumentNullException.